### PR TITLE
Fix linting errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,10 @@ repos:
     rev: 0.8.1
     hooks:
       - id: nbstripout
+  - repo: local
+    hooks:
+      - id: ty
+        name: ty check
+        args: [--exit-zero]
+        entry: uvx ty check . --ignore unresolved-import
+        language: python

--- a/nhpy/az.py
+++ b/nhpy/az.py
@@ -363,7 +363,7 @@ def load_data_file_old(
 # %%
 # TODO: at a later stage, we could package input args into a dict
 # to respect PLR0913 https://docs.astral.sh/ruff/rules/too-many-arguments/
-def load_model_run_results_file(
+def load_model_run_results_file(  # noqa PLR0913
     container_client: ContainerClient,
     version: str,
     dataset: str,

--- a/nhpy/check_full_results.py
+++ b/nhpy/check_full_results.py
@@ -143,11 +143,12 @@ def check_full_results(
     account_url = account_url or account_url_from_az
     container_name = container_name or container_name_from_az
 
-    params = _load_scenario_params(
-        results_path=scenario_path,
-        account_url=account_url,
-        container_name=container_name,
-    )
+    if account_url and container_name:
+        params = _load_scenario_params(
+            results_path=scenario_path,
+            account_url=account_url,
+            container_name=container_name,
+        )
 
     try:
         results_path_dict = _construct_results_path(params=params)
@@ -191,7 +192,7 @@ def check_full_results(
 
 
 # %%
-def main(level: Logger = INFO) -> int:
+def main(level: int = INFO) -> int:
     """
     CLI entry point when module is run directly.
 

--- a/nhpy/process_data.py
+++ b/nhpy/process_data.py
@@ -1,6 +1,7 @@
 """Functions to process model data in format suitable for model results"""
 
 from collections import defaultdict
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -153,7 +154,7 @@ def process_model_runs_dict(
                 v_ = np.concatenate((v_, zeros))
         if len(v_) != n_runs:
             raise ValueError(f"Length of array for {k} is not equal to n_runs")
-        x = np.percentile(v_, [10, 50, 90])
+        x = cast(np.ndarray, np.percentile(v_, [10, 50, 90]))
         model_runs_df.loc[k, "lwr_ci"] = x[0]
         model_runs_df.loc[k, "median"] = x[1]
         model_runs_df.loc[k, "mean"] = v_.mean()

--- a/nhpy/process_params.py
+++ b/nhpy/process_params.py
@@ -2,7 +2,8 @@
 
 
 def upgrade_ndg(params: dict) -> dict:
-    """Upgrades pre-v3.3 parameters with the old format for non-demographic growth so they can be used with model v3.3 onwards
+    """Upgrades pre-v3.3 parameters with the old format for non-demographic growth
+    so they can be used with model v3.3 onwards
 
     Args:
         params (dict): Full model parameters in JSON format

--- a/nhpy/process_results.py
+++ b/nhpy/process_results.py
@@ -1,5 +1,7 @@
 """Functions to process results files"""
 
+from typing import Callable
+
 import numpy as np
 import pandas as pd
 
@@ -229,7 +231,9 @@ def compare_stepcounts(results_dict: dict, trust: str) -> pd.DataFrame:
     return combined
 
 
-def create_time_profiles(horizon_years: int, year: int) -> dict[str, callable]:
+def create_time_profiles(
+    horizon_years: int, year: int
+) -> dict[str, Callable[[int], float]]:
     """Create time profile functions. Creates time_profiles_dict which is taken by
     the get_time_profiles_factor function
 
@@ -240,12 +244,12 @@ def create_time_profiles(horizon_years: int, year: int) -> dict[str, callable]:
     :rtype: dict[str, callable]
     """
     return {
-        "none": 1,
-        "linear": year / horizon_years,
-        "front_loaded": np.sqrt(horizon_years**2 - (horizon_years - year) ** 2)
+        "none": lambda _: 1.0,
+        "linear": lambda _: year / horizon_years,
+        "front_loaded": lambda _: np.sqrt(horizon_years**2 - (horizon_years - year) ** 2)
         / horizon_years,
-        "back_loaded": 1 - np.sqrt(horizon_years**2 - year**2) / horizon_years,
-        "step": lambda y: int(year >= y),
+        "back_loaded": lambda _: 1 - np.sqrt(horizon_years**2 - year**2) / horizon_years,
+        "step": lambda y: float(year >= y),
     }
 
 

--- a/nhpy/run_full_results.py
+++ b/nhpy/run_full_results.py
@@ -92,7 +92,7 @@ def _extract_scenario_components(results_path: str) -> tuple[str, str, str, str]
 
 
 # %%
-def _prepare_full_results_params(params: dict[str, str]) -> dict[str, str]:
+def _prepare_full_results_params(params: dict[str, object]) -> dict[str, object]:
     """
     Modify parameters for a full results run.
 
@@ -118,7 +118,7 @@ def _prepare_full_results_params(params: dict[str, str]) -> dict[str, str]:
 
 # %%
 def _submit_api_request(
-    params: dict[str, str],
+    params: dict[str, object],
     api_url: str,
     api_key: str,
     timeout: int = 30,
@@ -164,10 +164,12 @@ def _submit_api_request(
         server_datetime = response_data["create_datetime"]
         response_data["create_datetime"] = response_data["original_datetime"]
         logger.info(
-            dedent(f"""
+            dedent(
+                f"""
             ✅ API request successful 🥳
             {Colours.GREEN}Server datetime: {server_datetime}{Colours.RESET}
-            Original datetime: {response_data["original_datetime"]}""").strip()
+            Original datetime: {response_data["original_datetime"]}"""
+            ).strip()
         )
 
         return server_datetime
@@ -223,25 +225,32 @@ def run_scenario_with_full_results(
         logger.error(f"run_scenario_with_full_results():Invalid results path: {e}")
         raise
 
-    # Load scenario parameters
-    params = _load_scenario_params(
-        results_path=results_path, account_url=account_url, container_name=container_name
-    )
+    if account_url and container_name:
+        # Load scenario parameters
+        params = _load_scenario_params(
+            results_path=results_path,
+            account_url=account_url,
+            container_name=container_name,
+        )
 
-    # Prepare parameters for full results run
-    mod_params = _prepare_full_results_params(params=params)
+        # Prepare parameters for full results run
+        mod_params = _prepare_full_results_params(params=params)
 
-    # Submit API request
-    server_datetime = _submit_api_request(
-        params=mod_params, api_url=api_url, api_key=api_key, timeout=Constants.TIMEOUT_SEC
-    )
+        # Submit API request
+        if api_url and api_key:
+            server_datetime = _submit_api_request(
+                params=mod_params,
+                api_url=api_url,
+                api_key=api_key,
+                timeout=Constants.TIMEOUT_SEC,
+            )
 
-    mod_params["create_datetime"] = server_datetime
+        mod_params["create_datetime"] = server_datetime
 
-    # Construct and return result paths
-    full_results_params = _construct_results_path(params=mod_params)
+        # Construct and return result paths
+        full_results_params = _construct_results_path(params=mod_params)
 
-    return full_results_params
+        return full_results_params
 
 
 # %%

--- a/nhpy/utils.py
+++ b/nhpy/utils.py
@@ -124,7 +124,7 @@ def _validate_environment_variables(required_vars: list[str]) -> EnvironmentConf
     if missing_vars:
         error_msg = f"Missing required environment variables: {', '.join(missing_vars)}"
         logger.error(error_msg)
-        raise EnvironmentVariableError(error_msg)
+        raise EnvironmentVariableError([error_msg])
 
     return cast(EnvironmentConfig, env_vars)
 
@@ -161,7 +161,7 @@ def _load_environment_variables() -> EnvironmentConfig:
 
 
 # %%
-def _construct_results_path(params: dict[str, str]) -> ScenarioPaths:
+def _construct_results_path(params: dict[str, object]) -> ScenarioPaths:
     """
     Construct paths for the new scenario results.
 
@@ -194,14 +194,14 @@ def _construct_results_path(params: dict[str, str]) -> ScenarioPaths:
         json_path=json_path,
         aggregated_results_path=aggregated_results_path,
         full_results_path=full_results_path,
-        original_datetime=params["original_datetime"],
+        original_datetime=str(params["original_datetime"]),
     )
 
 
 # %%
 def _load_scenario_params(
     results_path: str, account_url: str, container_name: str
-) -> dict[str, str]:
+) -> dict[str, object]:
     """
     Load parameters from an existing scenario using load_agg_params.
 

--- a/notebooks/PRODUCT_detailed_activity-avoided/databricks_national_activity_avoided.py
+++ b/notebooks/PRODUCT_detailed_activity-avoided/databricks_national_activity_avoided.py
@@ -3,9 +3,13 @@
 # MAGIC # Population based model
 # MAGIC ## Link activity avoided back to original data
 # MAGIC
-# MAGIC This notebook uses Databricks to link the activity avoided saved from each Monte Carlo simulation back to the original data, aggregating the inpatients activity avoided by HRG, an indicator on whether the length of stay from admission to discharge is zero, and pod.
+# MAGIC This notebook uses Databricks to link the activity avoided saved from each
+# Monte Carlo simulation back to the original data, aggregating the inpatients activity
+# avoided by HRG, an indicator on whether the length of stay from admission to discharge
+# is zero, and pod.
 # MAGIC
-# MAGIC For this notebook to work we first need to have run the national_run notebook from nhp_model, with save_full_model_results set to TRUE for inpatients.
+# MAGIC For this notebook to work we first need to have run the national_run notebook
+# from nhp_model, with save_full_model_results set to TRUE for inpatients.
 # MAGIC
 # MAGIC This notebook currently only works for IP, not OP or AAE.
 
@@ -40,8 +44,8 @@ with open(f"{params_path}/params.json", "rb") as f:
 scenario_name = params["scenario"]
 
 # COMMAND ----------
-
-data_version = results_folder.split("/")[1] + ".0" # Check that there hasn't been a patch release of data - this is very rare
+# Check that there hasn't been a patch release of data - this is very rare
+data_version = results_folder.split("/")[1] + ".0"
 data_path = f"/Volumes/nhp/model_data/files/{data_version}"
 
 # COMMAND ----------
@@ -83,23 +87,29 @@ for run in range(1, 257):
 # COMMAND ----------
 
 model_runs_df = process_data.process_model_runs_dict(
-    model_runs, columns=["pod", "los_group", "sushrg", "measure"], all_runs_kept = True
+    model_runs, columns=["pod", "los_group", "sushrg", "measure"],
+    all_runs_kept = True
 )
-notebook_admissions = model_runs_df.loc[(slice(None), slice(None), slice(None), "admissions")].sum().loc["mean"]
+notebook_admissions = model_runs_df.loc[
+    (slice(None), slice(None), slice(None), "admissions")].sum().loc["mean"]
 notebook_admissions
 
 # COMMAND ----------
 
-# Checking results of this notebook against "principal" from main model results avoided_activity
+# Checking results of this notebook against "principal" from main model results
+# avoided_activity
 
 activity_avoided = pd.read_parquet(f"{params_path}/avoided_activity.parquet")
-assert (notebook_admissions *100) == (activity_avoided[activity_avoided["measure"] == "admissions"]["value"].sum()/256)
+assert (notebook_admissions *100) == (
+    activity_avoided[activity_avoided["measure"] == "admissions"]["value"].sum()/256)
 
 # COMMAND ----------
 
 
-notebook_beddays = model_runs_df.loc[(slice(None), slice(None), slice(None), "beddays")].sum().loc["mean"]
-assert (notebook_beddays * 100) == (activity_avoided[activity_avoided["measure"] == "beddays"]["value"].sum()/256)
+notebook_beddays = model_runs_df.loc[
+    (slice(None), slice(None), slice(None), "beddays")].sum().loc["mean"]
+assert (notebook_beddays * 100) == (
+    activity_avoided[activity_avoided["measure"] == "beddays"]["value"].sum()/256)
 
 # COMMAND ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 line-length = 90
 target-version = "py312"
+exclude = ["*.ipynb"]
 
 [tool.ruff.lint]
 # Simple rules: pylint + isort
@@ -84,6 +85,7 @@ select = [
     "I",                      # isort (import sorting)
     "PL",                     # pylint rules
 ]
+exclude = ["*.ipynb"]
 
 [tool.ty.src]
 exclude = ["notebooks", "tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ select = [
     "PL",                     # pylint rules
 ]
 
+[tool.ty.src]
+exclude = ["notebooks", "tests"]
+
 [tool.ty.rules]
 invalid-argument-type = "warn"
 invalid-key = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 line-length = 90
 target-version = "py312"
-exclude = ["*.ipynb"]
+exclude = ["*.ipynb", "databricks_*"]
 
 [tool.ruff.lint]
 # Simple rules: pylint + isort

--- a/tests/test_check_full_results.py
+++ b/tests/test_check_full_results.py
@@ -181,7 +181,7 @@ def test_public_api():
 
     # Verify check_full_results is in __all__
     try:
-        from nhpy.check_full_results import __all__
+        from nhpy.check_full_results import __all__  # noqa PLC0415
 
         if "check_full_results" in __all__:
             logger.info("  ✅ check_full_results properly exported")
@@ -191,7 +191,7 @@ def test_public_api():
         logger.info("  ⚠️  No __all__ defined in module")
 
     # Verify function signature
-    import inspect
+    import inspect  # noqa PLC0415
 
     sig = inspect.signature(check_full_results)
     params = list(sig.parameters.keys())
@@ -218,7 +218,7 @@ def main():
 
         logger.info("\n🎉 All smoke tests passed!")
         logger.info(
-            "💡 To test with real Azure Storage, use a valid scenario path with proper credentials"
+            "💡 To test with real Azure Storage, use a valid scenario path with proper credentials"  # noqa E501
         )
 
     except Exception as e:


### PR DESCRIPTION
This PR:
- Fixes linting and typing errors raised by `ty` and `ruff`, closes #24 
- Reinstates `ty` in precommit hook

I have checked all smoke tests still run.

🧪 To test this PR, use the scenario `aggregated-model-results/v4.1/RJ7/test-yh-full-results/20250909_200111/` to check the following scripts / notebooks run without issues:

- [ ] `notebooks/PRODUCT_time-profiles/produce_time_profiles.ipynb` (this was impacted by the change in the `create_time_profiles` function)
- [ ] `notebooks/PRODUCT_detailed_results/detailed_results_v4-1.py` (this is our most important product)

NOTE: `nhpy.run_full_results` will not work unless you have your IP whitelisted with nhp-api-v2. I will remove our dependency on this API in the next PR, by closing #21 

