### PR TITLE
Add troubleshoot section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,3 +215,4 @@ If you have problems running code, you could:
 
 * disconnect from the VPN and try again
 * try VS Code in preference to Positron
+* check .env values are correct


### PR DESCRIPTION
Spurred by a chat with YiWen, when running `uv run python -m nhpy.pipeline <path to json>` worked for me in VS Code but not Positron.

* Began a troubleshooting section in the README.
* Added two bullets that might help people if they're having trouble running the code.
