### PR TITLE
Create alternative detailed results

### DIFF
--- a/nhpy/config.py
+++ b/nhpy/config.py
@@ -75,3 +75,42 @@ class EmptyContainerError(Exception):
             "exists but contains no blobs"
         )
         super().__init__(self.message)
+
+
+class DetailedResultsConfig:
+    def __init__(
+        self,
+        ip_agg_cols: list[str],
+        op_agg_cols: list[str],
+        aae_agg_cols: list[str],
+        custom_age_groups: bool,
+    ):
+        self.ip_agg_cols = ip_agg_cols
+        self.op_agg_cols = op_agg_cols
+        self.aae_agg_cols = aae_agg_cols
+        self.custom_age_groups = custom_age_groups
+
+
+class DetailedResultsStandard(DetailedResultsConfig):
+    def __init__(self, custom_age_groups: bool = False):
+        super().__init__(
+            ip_agg_cols=[
+                "sitetret",
+                "age_group",
+                "sex",
+                "pod",
+                "tretspef",
+                "los_group",
+                "maternity_delivery_in_spell",
+            ],
+            op_agg_cols=["sitetret", "pod", "age_group", "tretspef"],
+            aae_agg_cols=[
+                "sitetret",
+                "pod",
+                "age_group",
+                "attendance_category",
+                "aedepttype",
+                "acuity",
+            ],
+            custom_age_groups=custom_age_groups,
+        )

--- a/nhpy/config.py
+++ b/nhpy/config.py
@@ -7,6 +7,8 @@ single source of truth for error handling and status codes throughout the
 application.
 """
 
+import pandas as pd
+
 
 # %%
 # Exit codes
@@ -90,6 +92,11 @@ class DetailedResultsConfig:
         self.aae_agg_cols = aae_agg_cols
         self.custom_age_groups = custom_age_groups
 
+    @staticmethod
+    def age_groups(age: pd.Series) -> pd.Series:
+        """Implemented in subclasses"""
+        raise NotImplementedError()
+
 
 class DetailedResultsStandard(DetailedResultsConfig):
     def __init__(self, custom_age_groups: bool = False):
@@ -114,3 +121,52 @@ class DetailedResultsStandard(DetailedResultsConfig):
             ],
             custom_age_groups=custom_age_groups,
         )
+
+
+class DetailedResultsHRG(DetailedResultsConfig):
+    def __init__(self, custom_age_groups: bool = True):
+        super().__init__(
+            ip_agg_cols=[
+                "sitetret",
+                "age_group",
+                "sex",
+                "pod",
+                "tretspef",
+                "sushrg",
+                "maternity_delivery_in_spell",
+            ],
+            op_agg_cols=["sitetret", "pod", "age_group", "tretspef"],
+            aae_agg_cols=[
+                "sitetret",
+                "pod",
+                "age_group",
+                "attendance_category",
+                "aedepttype",
+                "acuity",
+            ],
+            custom_age_groups=custom_age_groups,
+        )
+
+    @staticmethod
+    def age_groups(age: pd.Series) -> pd.Series:
+        """Cut age into groups
+
+        Takes a pandas Series of age's and cut's into discrete intervals
+
+        :param age: a Series of ages
+        :type age: pandas.Series
+
+        :returns: a Series of age groups
+        :rtype: pandas.Series
+        """
+        return pd.cut(
+            age.fillna(-1),
+            [-1, 0, 1, 18, 1000],
+            right=False,
+            labels=[
+                "Unknown",
+                "0",
+                "1-17",
+                "18+",
+            ],
+        ).astype(str)

--- a/nhpy/pipeline.py
+++ b/nhpy/pipeline.py
@@ -368,7 +368,11 @@ def main() -> int:
         "-r", "--results-container", help="Azure Storage container for results"
     )
     parser.add_argument("-d", "--data-container", help="Azure Storage container for data")
-
+    parser.add_argument(
+        "--agg-type",
+        help="Which aggregation type to produce for detailed results",
+        default="standard",
+    )
     args = parser.parse_args()
 
     try:
@@ -438,6 +442,7 @@ def main() -> int:
             account_url=args.account_url,
             results_container=args.results_container,
             data_container=args.data_container,
+            agg_type=args.agg_type,
         )
 
         logger.info(f"{SUCCESS_COLOR}Pipeline completed successfully!{RESET}")

--- a/nhpy/pipeline.py
+++ b/nhpy/pipeline.py
@@ -372,6 +372,7 @@ def main() -> int:
         "--agg-type",
         help="Which aggregation type to produce for detailed results",
         default="standard",
+        choices=["standard", "hrg"],
     )
     args = parser.parse_args()
 

--- a/nhpy/process_data.py
+++ b/nhpy/process_data.py
@@ -146,7 +146,7 @@ def process_ip_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
             "sex",
             "pod",
             "tretspef",
-            "los_group",
+            "sushrg",
             "maternity_delivery_in_spell",
         ],
         dropna=False,
@@ -171,7 +171,7 @@ def process_ip_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
             "sex",
             "pod",
             "tretspef",
-            "los_group",
+            "sushrg",
             "maternity_delivery_in_spell",
             "measure",
         ]

--- a/nhpy/process_data.py
+++ b/nhpy/process_data.py
@@ -113,13 +113,15 @@ def process_model_runs_dict(
     return model_runs_df
 
 
-def process_ip_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
+def process_ip_detailed_results(
+    data: pd.DataFrame, ip_agg_cols: list[str]
+) -> pd.DataFrame:
     """Process the IP detailed results, adding pod and age_group, and grouping by
-    sitetret, age_group, sex, pod, tretspef, los_group, maternity_delivery_in_spell,
-    and measure
+    specified columns
 
     Args:
         data: the IP activity in each Monte Carlo simulation
+        ip_agg_cols: list of column names to aggregate by
 
     Returns:
         The processed and aggregated data
@@ -140,15 +142,7 @@ def process_ip_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
     data = process_ip_results(data, los_groups_detailed)
     # Explicitly cast the result to DataFrame to satisfy type checking
     grouped_data = data.groupby(
-        [
-            "sitetret",
-            "age_group",
-            "sex",
-            "pod",
-            "tretspef",
-            "sushrg",
-            "maternity_delivery_in_spell",
-        ],
+        ip_agg_cols,
         dropna=False,
     )[["admissions", "beddays", "procedures"]].sum()
     data = pd.DataFrame(grouped_data)
@@ -164,28 +158,20 @@ def process_ip_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
     )
     # remove any row where the measure value is 0
     data = data[data["value"] > 0].reset_index()
-    data = data.groupby(
-        [
-            "sitetret",
-            "age_group",
-            "sex",
-            "pod",
-            "tretspef",
-            "sushrg",
-            "maternity_delivery_in_spell",
-            "measure",
-        ]
-    ).sum()
+    data = data.groupby(ip_agg_cols + ["measure"]).sum()
 
     return data
 
 
-def process_op_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
+def process_op_detailed_results(
+    data: pd.DataFrame, op_agg_cols: list[str]
+) -> pd.DataFrame:
     """Process the OP detailed results, adding pod and age_group, and grouping by
-    sitetret, age_group, sex, pod, tretspef, and measure
+    specified columns
 
     Args:
         data: the IP activity in each Monte Carlo simulation
+        op_agg_cols: list of column names to aggregate by
 
     Returns:
         The processed and aggregated data
@@ -197,9 +183,7 @@ def process_op_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
     grouped_data = (
         data.drop(["attendances", "tele_attendances"], axis="columns")
         .merge(measures, on="rn")
-        .groupby(
-            ["sitetret", "pod", "age_group", "tretspef", "measure"],
-        )[["value"]]
+        .groupby(op_agg_cols + ["measure"])[["value"]]
         .sum()
         .sort_index()
     )
@@ -207,12 +191,13 @@ def process_op_detailed_results(data: pd.DataFrame) -> pd.DataFrame:
     return data
 
 
-def process_op_converted_from_ip(data: pd.DataFrame) -> pd.Series:
+def process_op_converted_from_ip(data: pd.DataFrame, op_agg_cols: list[str]) -> pd.Series:
     """Process the OP activity converted from IP, adding pod and age_group, and
-    grouping by sitetret, age_group, sex, pod, tretspef, and measure.
+    grouping by specified columns
 
     Args:
         data: the OP activity converted from IP in each Monte Carlo simulation
+        op_agg_cols: list of column names to aggregate by
 
     Returns:
         The processed and aggregated data
@@ -224,7 +209,7 @@ def process_op_converted_from_ip(data: pd.DataFrame) -> pd.Series:
     data["measure"] = "attendances"
     return (
         data.rename(columns={"attendances": "value"})
-        .groupby(["sitetret", "pod", "age_group", "tretspef", "measure"])["value"]
+        .groupby(op_agg_cols + ["measure"])["value"]
         .sum()
     )
 
@@ -257,13 +242,13 @@ def combine_converted_with_main_results(
     return result
 
 
-def process_aae_results(data: pd.DataFrame) -> pd.DataFrame:
+def process_aae_results(data: pd.DataFrame, aae_agg_cols: list[str]) -> pd.DataFrame:
     """Process the AAE detailed results, adding pod and age_group,
-    and grouping by sitetret, pod, age_group, attendance_category,
-    aedepttype, acuity, and measure
+    and grouping by specified columns
 
     Args:
         data: the AAE activity in each Monte Carlo simulation
+        aae_agg_cols: list of column names to aggregate by
 
     Returns:
         The processed and aggregated data
@@ -273,27 +258,19 @@ def process_aae_results(data: pd.DataFrame) -> pd.DataFrame:
     data.loc[data["is_ambulance"], "measure"] = "ambulance"
 
     # Explicitly cast the result to DataFrame to satisfy type checking
-    grouped_data = data.groupby(
-        [
-            "sitetret",
-            "pod",
-            "age_group",
-            "attendance_category",
-            "aedepttype",
-            "acuity",
-            "measure",
-        ]
-    )[["arrivals"]].sum()
+    grouped_data = data.groupby(aae_agg_cols + ["measure"])[["arrivals"]].sum()
     return pd.DataFrame(grouped_data)
 
 
-def process_aae_converted_from_ip(data: pd.DataFrame) -> pd.Series:
+def process_aae_converted_from_ip(
+    data: pd.DataFrame, aae_agg_cols: list[str]
+) -> pd.Series:
     """Process the AAE SDEC activity converted from IP, adding pod and age_group,
-    and grouping by sitetret, age_group, pod, aedepttype, attendance_category, acuity
-    and measure.
+    and grouping by specified columns.
 
     Args:
         data: the AAE SDEC activity converted from IP in each Monte Carlo simulation
+        aae_agg_cols: list of column names to aggregate by
 
     Returns:
         The processed and aggregated data
@@ -303,17 +280,7 @@ def process_aae_converted_from_ip(data: pd.DataFrame) -> pd.Series:
     data["pod"] = "aae_type-05"
     data = data.rename(columns={"group": "measure"})
     # Group the data and return a Series
-    result_series = data.groupby(
-        [
-            "sitetret",
-            "pod",
-            "age_group",
-            "attendance_category",
-            "aedepttype",
-            "acuity",
-            "measure",
-        ]
-    )["arrivals"].sum()
+    result_series = data.groupby(aae_agg_cols + ["measure"])["arrivals"].sum()
 
     return result_series
 

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -54,7 +54,7 @@ from azure.core.exceptions import (
 from tqdm import tqdm
 
 from nhpy import az, process_data, process_results
-from nhpy.config import ExitCodes
+from nhpy.config import DetailedResultsStandard, ExitCodes
 from nhpy.types import ProcessContext
 from nhpy.utils import (
     EnvironmentVariableError,
@@ -198,7 +198,10 @@ def age_groups(age: pd.Series) -> pd.Series:
 
 
 def _process_inpatient_results(
-    ctx: ProcessContext, output_dir: str, custom_age_groups: bool = False
+    ctx: ProcessContext,
+    output_dir: str,
+    ip_agg_cols: list[str],
+    custom_age_groups: bool = False,
 ) -> None:
     """
     Process inpatient detailed results.
@@ -285,16 +288,7 @@ def _process_inpatient_results(
     # Process model runs dictionary after the loop completes
     model_runs_df = process_data.process_model_runs_dict(
         model_runs,
-        columns=[
-            "sitetret",
-            "age_group",
-            "sex",
-            "pod",
-            "tretspef",
-            "sushrg",
-            "maternity_delivery_in_spell",
-            "measure",
-        ],
+        columns=ip_agg_cols + ["measure"],
     )
     logger.info(
         f"IP data processed into dataframe, memory usage: {get_memory_usage():.2f} MB"
@@ -703,6 +697,7 @@ def run_detailed_results(
     account_url: str | None = None,
     results_container: str | None = None,
     data_container: str | None = None,
+    agg_type: str = "standard",
 ) -> dict[str, str]:
     """
     Generate detailed results for a model scenario.
@@ -769,9 +764,14 @@ def run_detailed_results(
     # Track if we processed any new results
     processed_new_results = False
 
+    # Which type of detailed results to produce
+    if agg_type == "standard":
+        config = DetailedResultsStandard()
     # Process each type of results if they don't already exist
     if not ip_exists:
-        _process_inpatient_results(context, output_dir)
+        _process_inpatient_results(
+            context, output_dir, config.ip_agg_cols, config.custom_age_groups
+        )
         processed_new_results = True
 
     if not op_exists:
@@ -828,6 +828,11 @@ def main() -> int:
     parser.add_argument("--account-url", help="Azure Storage account URL")
     parser.add_argument("--results-container", help="Azure Storage container for results")
     parser.add_argument("--data-container", help="Azure Storage container for data")
+    parser.add_argument(
+        "--agg-type",
+        help="Which aggregation type to produce for detailed results",
+        default="standard",
+    )
 
     # Add mutually exclusive processing flags to match Polars implementation
     processing_group = parser.add_mutually_exclusive_group()
@@ -884,6 +889,7 @@ def main() -> int:
             account_url=args.account_url,
             results_container=args.results_container,
             data_container=args.data_container,
+            agg_type=args.agg_type,
         )
 
         logger.info("🎉 Detailed results generated successfully!")

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -308,22 +308,7 @@ def _process_inpatient_results(
         .astype(int)
     )
     detailed_beddays_principal = (
-        model_runs_df.loc[
-            (
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                "beddays",
-            ),
-            :,
-        ]
-        .sum()
-        .loc["mean"]
-        .astype(int)
+        model_runs_df.xs("beddays", level="measure").sum().loc["mean"].astype(int)
     )
 
     try:
@@ -461,7 +446,7 @@ def _process_outpatient_results(
     # Validate results
     detailed_attendances_principal = (
         op_model_runs_df.round(1)
-        .loc[(slice(None), slice(None), slice(None), slice(None), "attendances"), :]
+        .xs("attendances", level="measure")
         .sum()
         .astype(int)
         .loc["mean"]
@@ -515,21 +500,7 @@ def _validate_aae_metric(
         metric_label: Label for the measure in logs (e.g., "Ambulance", "Walk-in")
     """
     detailed_value = (
-        ae_model_runs_df.loc[
-            (
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                slice(None),
-                measure_name,
-            ),
-            :,
-        ]
-        .sum()
-        .loc["mean"]
-        .round(0)
+        ae_model_runs_df.xs(measure_name, level="measure").sum().loc["mean"].round(0)
     )
 
     default_value = (

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -800,6 +800,7 @@ def main() -> int:
         "--agg-type",
         help="Which aggregation type to produce for detailed results",
         default="standard",
+        choices=["standard", "hrg"],
     )
 
     # Add mutually exclusive processing flags to match Polars implementation

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -54,7 +54,12 @@ from azure.core.exceptions import (
 from tqdm import tqdm
 
 from nhpy import az, process_data, process_results
-from nhpy.config import DetailedResultsStandard, ExitCodes
+from nhpy.config import (
+    DetailedResultsConfig,
+    DetailedResultsHRG,
+    DetailedResultsStandard,
+    ExitCodes,
+)
 from nhpy.types import ProcessContext
 from nhpy.utils import (
     EnvironmentVariableError,
@@ -173,35 +178,8 @@ def _check_results_exist(output_dir: str, scenario_name: str, activity_type: str
     return False
 
 
-def age_groups(age: pd.Series) -> pd.Series:
-    """Cut age into groups
-
-    Takes a pandas Series of age's and cut's into discrete intervals
-
-    :param age: a Series of ages
-    :type age: pandas.Series
-
-    :returns: a Series of age groups
-    :rtype: pandas.Series
-    """
-    return pd.cut(
-        age.fillna(-1),
-        [-1, 0, 1, 18, 1000],
-        right=False,
-        labels=[
-            "Unknown",
-            "0",
-            "1-17",
-            "18+",
-        ],
-    ).astype(str)
-
-
 def _process_inpatient_results(
-    ctx: ProcessContext,
-    output_dir: str,
-    ip_agg_cols: list[str],
-    custom_age_groups: bool = False,
+    ctx: ProcessContext, output_dir: str, config: DetailedResultsConfig
 ) -> None:
     """
     Process inpatient detailed results.
@@ -239,8 +217,8 @@ def _process_inpatient_results(
         activity_type="ip",
         year=baseline_year,
     )
-    if custom_age_groups:
-        original_df["age_group"] = age_groups(original_df["age"])
+    if config.custom_age_groups:
+        original_df["age_group"] = config.age_groups(original_df["age"])
 
     # Pre-allocate dictionary
     model_runs = {}
@@ -271,7 +249,7 @@ def _process_inpatient_results(
 
         # Use the pre-created reference dataframe
         merged = reference_df.merge(df, on="rn", how="inner")
-        results = process_data.process_ip_detailed_results(merged, ip_agg_cols)
+        results = process_data.process_ip_detailed_results(merged, config.ip_agg_cols)
 
         # More efficient dictionary update
         results_dict = results.to_dict()
@@ -288,7 +266,7 @@ def _process_inpatient_results(
     # Process model runs dictionary after the loop completes
     model_runs_df = process_data.process_model_runs_dict(
         model_runs,
-        columns=ip_agg_cols + ["measure"],
+        columns=config.ip_agg_cols + ["measure"],
     )
     logger.info(
         f"IP data processed into dataframe, memory usage: {get_memory_usage():.2f} MB"
@@ -757,11 +735,11 @@ def run_detailed_results(
     # Which type of detailed results to produce
     if agg_type == "standard":
         config = DetailedResultsStandard()
+    if agg_type == "hrg":
+        config = DetailedResultsHRG()
     # Process each type of results if they don't already exist
     if not ip_exists:
-        _process_inpatient_results(
-            context, output_dir, config.ip_agg_cols, config.custom_age_groups
-        )
+        _process_inpatient_results(context, output_dir, config)
         processed_new_results = True
 
     if not op_exists:

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -271,7 +271,7 @@ def _process_inpatient_results(
 
         # Use the pre-created reference dataframe
         merged = reference_df.merge(df, on="rn", how="inner")
-        results = process_data.process_ip_detailed_results(merged)
+        results = process_data.process_ip_detailed_results(merged, ip_agg_cols)
 
         # More efficient dictionary update
         results_dict = results.to_dict()
@@ -332,8 +332,7 @@ def _process_inpatient_results(
 
 
 def _process_outpatient_results(
-    context: ProcessContext,
-    output_dir: str,
+    context: ProcessContext, output_dir: str, op_agg_cols: list[str]
 ) -> None:
     """
     Process outpatient detailed results.
@@ -400,7 +399,7 @@ def _process_outpatient_results(
 
         # Use the pre-created reference dataframe
         merged = reference_df.merge(df, on="rn", how="inner")
-        results = process_data.process_op_detailed_results(merged)
+        results = process_data.process_op_detailed_results(merged, op_agg_cols)
 
         # Load conversion data with batch functionality
         df_conv = az.load_model_run_results_file(
@@ -416,7 +415,7 @@ def _process_outpatient_results(
             },
         )
 
-        df_conv = process_data.process_op_converted_from_ip(df_conv)
+        df_conv = process_data.process_op_converted_from_ip(df_conv, op_agg_cols)
         results = process_data.combine_converted_with_main_results(df_conv, results)
 
         # More efficient dictionary update
@@ -433,7 +432,7 @@ def _process_outpatient_results(
 
     # Process results
     op_model_runs_df = process_data.process_model_runs_dict(
-        op_model_runs, columns=["sitetret", "pod", "age_group", "tretspef", "measure"]
+        op_model_runs, columns=op_agg_cols + ["measure"]
     )
 
     # Validate results
@@ -513,8 +512,7 @@ def _validate_aae_metric(
 
 
 def _process_aae_results(
-    context: ProcessContext,
-    output_dir: str,
+    context: ProcessContext, output_dir: str, aae_agg_cols: list[str]
 ) -> None:
     """
     Process A&E detailed results.
@@ -581,7 +579,7 @@ def _process_aae_results(
 
         # Use the pre-created reference dataframe
         merged = reference_df.merge(df, on="rn", how="inner")
-        results = process_data.process_aae_results(merged)
+        results = process_data.process_aae_results(merged, aae_agg_cols)
 
         # Load conversion data with batch functionality
         df_conv = az.load_model_run_results_file(
@@ -597,7 +595,7 @@ def _process_aae_results(
             },
         )
 
-        df_conv = process_data.process_aae_converted_from_ip(df_conv)
+        df_conv = process_data.process_aae_converted_from_ip(df_conv, aae_agg_cols)
         results = process_data.combine_converted_with_main_results(df_conv, results)
 
         # More efficient dictionary update
@@ -615,15 +613,7 @@ def _process_aae_results(
     # Process results
     ae_model_runs_df = process_data.process_model_runs_dict(
         ae_model_runs,
-        columns=[
-            "sitetret",
-            "pod",
-            "age_group",
-            "attendance_category",
-            "aedepttype",
-            "acuity",
-            "measure",
-        ],
+        columns=aae_agg_cols + ["measure"],
     )
 
     # Validate results
@@ -775,11 +765,11 @@ def run_detailed_results(
         processed_new_results = True
 
     if not op_exists:
-        _process_outpatient_results(context, output_dir)
+        _process_outpatient_results(context, output_dir, config.op_agg_cols)
         processed_new_results = True
 
     if not ae_exists:
-        _process_aae_results(context, output_dir)
+        _process_aae_results(context, output_dir, config.aae_agg_cols)
         processed_new_results = True
 
     if processed_new_results:

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -198,8 +198,7 @@ def age_groups(age: pd.Series) -> pd.Series:
 
 
 def _process_inpatient_results(
-    ctx: ProcessContext,
-    output_dir: str,
+    ctx: ProcessContext, output_dir: str, custom_age_groups: bool = False
 ) -> None:
     """
     Process inpatient detailed results.
@@ -237,8 +236,8 @@ def _process_inpatient_results(
         activity_type="ip",
         year=baseline_year,
     )
-    # overwrite age_group
-    original_df["age_group"] = age_groups(original_df["age"])
+    if custom_age_groups:
+        original_df["age_group"] = age_groups(original_df["age"])
 
     # Pre-allocate dictionary
     model_runs = {}

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -173,6 +173,30 @@ def _check_results_exist(output_dir: str, scenario_name: str, activity_type: str
     return False
 
 
+def age_groups(age: pd.Series) -> pd.Series:
+    """Cut age into groups
+
+    Takes a pandas Series of age's and cut's into discrete intervals
+
+    :param age: a Series of ages
+    :type age: pandas.Series
+
+    :returns: a Series of age groups
+    :rtype: pandas.Series
+    """
+    return pd.cut(
+        age.fillna(-1),
+        [-1, 0, 1, 18, 1000],
+        right=False,
+        labels=[
+            "Unknown",
+            "0",
+            "1-17",
+            "18+",
+        ],
+    ).astype(str)
+
+
 def _process_inpatient_results(
     ctx: ProcessContext,
     output_dir: str,
@@ -213,6 +237,8 @@ def _process_inpatient_results(
         activity_type="ip",
         year=baseline_year,
     )
+    # overwrite age_group
+    original_df["age_group"] = age_groups(original_df["age"])
 
     # Pre-allocate dictionary
     model_runs = {}
@@ -266,7 +292,7 @@ def _process_inpatient_results(
             "sex",
             "pod",
             "tretspef",
-            "los_group",
+            "sushrg",
             "maternity_delivery_in_spell",
             "measure",
         ],
@@ -664,7 +690,7 @@ def _process_aae_results(
 def suppress_small_counts(
     df: pd.DataFrame,
     suppress_cols: List[str],
-    count_col: str = "value",
+    count_col: str = "baseline",
     threshold: int = 5,
 ) -> pd.DataFrame:
     """Suppression of small counts in detailed results. Filters dataframe to only rows with
@@ -698,13 +724,7 @@ def suppress_small_counts(
         )
         # bind suppressed rows with the ones that didn't need suppression
         df = pd.concat([keep, grouped], ignore_index=True)
-    try:
-        assert df[df[count_col] < threshold].empty
-        return df.set_index(full_index_cols).sort_index()
-    except AssertionError:
-        raise ValueError(
-            f"Small numbers still present after reaggregating by {suppress_cols}. Add additional columns to suppress_cols"
-        )
+    return df.set_index(full_index_cols).sort_index()
 
 
 def run_detailed_results(

--- a/nhpy/run_detailed_results.py
+++ b/nhpy/run_detailed_results.py
@@ -37,9 +37,13 @@ import gc
 import os
 import sys
 import time
+from ast import Assert
+from contextlib import suppress
 from logging import INFO
 from pathlib import Path
+from typing import List
 
+import pandas as pd
 import psutil
 from azure.core.exceptions import (
     ClientAuthenticationError,
@@ -655,6 +659,52 @@ def _process_aae_results(
     logger.info(
         f"Memory cleaned after A&E processing, current usage: {get_memory_usage():.2f} MB"
     )
+
+
+def suppress_small_counts(
+    df: pd.DataFrame,
+    suppress_cols: List[str],
+    count_col: str = "value",
+    threshold: int = 5,
+) -> pd.DataFrame:
+    """Suppression of small counts in detailed results. Filters dataframe to only rows with
+    small numbers, then groups together values in specified columns and re-aggregates.
+
+    Args:
+        df (pd.DataFrame): Processed detailed results
+        suppress_cols (List[str]): List of columns to use in suppressing small numbers,
+        in order of preference.
+        count_col (str, optional): The name of the column with the values to be suppressed
+        and aggregated.
+        Defaults to "value".
+        threshold (int, optional): Maximum count allowed in the count_col
+
+    Returns:
+        pd.DataFrame: Processed detailed results with small counts aggregated together
+    """
+    logger.info("Beginning suppression...")
+    full_index_cols = df.index.names.copy()
+    df = df.reset_index()
+    for col in suppress_cols:
+        keep = df[df[count_col] >= threshold].copy()
+        small = df[df[count_col] < threshold].copy()
+        # avoid suppression if we don't need to
+        if small.empty:
+            break
+        small[col] = "grouped"
+        # reaggregate
+        grouped = (
+            small.groupby(full_index_cols, dropna=False)[count_col].sum().reset_index()
+        )
+        # bind suppressed rows with the ones that didn't need suppression
+        df = pd.concat([keep, grouped], ignore_index=True)
+    try:
+        assert df[df[count_col] < threshold].empty
+        return df.set_index(full_index_cols).sort_index()
+    except AssertionError:
+        raise ValueError(
+            f"Small numbers still present after reaggregating by {suppress_cols}. Add additional columns to suppress_cols"
+        )
 
 
 def run_detailed_results(


### PR DESCRIPTION
Closes #88 
Closes #87 

We are being asked to produce different types of aggregations using the detailed results methodology. Have abstracted these out into a DetailedResultsConfig class to make it easier to track versions of detailed results and standardise how we work with them. The type of detailed results to produce is then selected in the CLI with the argument --agg-type.

So now we can run `uv run -m nhpy.pipeline --agg-type hrg PATH-TO-AGG-RESULTS` for the new hrg detailed results, or `uv run -m nhpy.pipeline --agg-type standard PATH-TO-AGG-RESULTS` for the old format of detailed results. If the --agg-type argument is not supplied it defaults to standard.

Have also coded up a new `suppress_small_counts` function which will be used later - it's not actually used anywhere at the moment

I will send some paths to agg results for testing via Teams. You should see that there are different columns in the files produced for IP (no differences in OP or A&E) and that the hrg agg-type also has different age groupings.